### PR TITLE
Implement Credential Key Rotation And UI

### DIFF
--- a/app/models/app_setting.rb
+++ b/app/models/app_setting.rb
@@ -4,9 +4,105 @@ class AppSetting < ApplicationRecord
   validates :default_time_zone, presence: true
   validates :default_sync_frequency_minutes, presence: true, numericality: { greater_than: 0 }
 
+  before_validation :persist_credentials
+  after_commit :reset_credential_store!, on: [:create, :update]
+
   class << self
     def instance
       first_or_create!(default_time_zone: "UTC", default_sync_frequency_minutes: 60)
     end
+  end
+
+  def apple_username
+    credential_store[:apple_username]
+  end
+
+  def apple_username=(value)
+    upsert_credential(:apple_username, value)
+  end
+
+  def apple_app_password
+    credential_store[:apple_app_password]
+  end
+
+  def apple_app_password=(value)
+    upsert_credential(:apple_app_password, value)
+  end
+
+  def credential_key_fingerprint
+    CalendarHub::CredentialEncryption.key_fingerprint
+  end
+
+  def rotate_credentials_key!
+    plaintext = credential_store.deep_dup
+    CalendarHub::CredentialEncryption.rotate!
+    reload
+    reset_credential_store!
+
+    if plaintext.present?
+      plaintext.each { |key, value| upsert_credential(key, value) }
+      persist_credentials
+      save!(validate: false)
+    end
+  end
+
+  private
+
+  def credential_store
+    @credential_store ||= begin
+      data = if apple_credentials_ciphertext.present?
+        CalendarHub::CredentialEncryption.decrypt(apple_credentials_ciphertext)
+      else
+        legacy_payload
+      end
+      data.with_indifferent_access
+    end
+  end
+
+  def legacy_payload
+    {}.tap do |memo|
+      username = sanitize(self[:apple_username])
+      password = sanitize(self[:apple_app_password])
+      memo[:apple_username] = username if username.present?
+      memo[:apple_app_password] = password if password.present?
+    end
+  end
+
+  def upsert_credential(key, raw_value)
+    sanitized = sanitize(raw_value)
+    if sanitized.present?
+      credential_store[key] = sanitized
+    else
+      credential_store.delete(key)
+    end
+  end
+
+  def sanitize(value)
+    return if value.nil?
+    return value unless value.is_a?(String)
+
+    value.strip.presence
+  end
+
+  def persist_credentials
+    return unless instance_variable_defined?(:@credential_store)
+
+    normalized = credential_store.each_with_object({}) do |(key, value), memo|
+      sanitized = sanitize(value)
+      memo[key] = sanitized if sanitized.present?
+    end
+
+    if normalized.present?
+      self.apple_credentials_ciphertext = CalendarHub::CredentialEncryption.encrypt(normalized)
+    elsif attribute_present?(:apple_credentials_ciphertext)
+      self.apple_credentials_ciphertext = nil
+    end
+
+    self[:apple_username] = nil if attribute_present?(:apple_username)
+    self[:apple_app_password] = nil if attribute_present?(:apple_app_password)
+  end
+
+  def reset_credential_store!
+    remove_instance_variable(:@credential_store) if instance_variable_defined?(:@credential_store)
   end
 end

--- a/app/services/calendar_hub/credential_encryption.rb
+++ b/app/services/calendar_hub/credential_encryption.rb
@@ -1,0 +1,294 @@
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+
+module CalendarHub
+  module CredentialEncryption
+    extend self
+
+    SALT = "calendar-source-salt"
+    KEY_BYTES = 32
+    HEX_LENGTH = KEY_BYTES * 2
+
+    class KeyRotationError < StandardError; end
+
+    def encrypt(payload)
+      hash = coerce_payload(payload)
+      normalized = normalize_payload(hash)
+      return if normalized.blank?
+
+      current_encryptor.encrypt_and_sign(normalized.to_json)
+    end
+
+    def decrypt(ciphertext)
+      return empty_hash if ciphertext.blank?
+
+      decrypted = current_encryptor.decrypt_and_verify(ciphertext)
+      coerce_payload(decrypted)
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage
+      legacy_decrypt(ciphertext) || empty_hash
+    end
+
+    def rotate!
+      mutex.synchronize do
+        ensure_key!
+        old_encryptor = @current_encryptor
+        new_key = generate_key
+        new_encryptor = build_encryptor(new_key)
+
+        ActiveRecord::Base.transaction do
+          reencrypt_calendar_sources(old_encryptor, new_encryptor)
+          reencrypt_app_settings(old_encryptor, new_encryptor)
+        end
+
+        write_key(new_key)
+        @current_key = new_key
+        @current_encryptor = new_encryptor
+      end
+    rescue => e
+      reset_cached_encryptor!
+      remove_instance_variable(:@legacy_encryptor) if instance_variable_defined?(:@legacy_encryptor)
+      raise KeyRotationError, e.message
+    end
+
+    def ensure_key!
+      if instance_variable_defined?(:@current_key) && @current_key.present?
+        return @current_key
+      end
+
+      mutex.synchronize do
+        unless instance_variable_defined?(:@current_key) && @current_key.present?
+          next_key = if key_path.exist?
+            read_key
+          else
+            generate_and_store_key
+          end
+          @current_key = next_key
+          @current_encryptor = build_encryptor(@current_key)
+        end
+      end
+
+      @current_key
+    end
+
+    def key_fingerprint
+      ensure_key!
+      Digest::SHA256.hexdigest(@current_key)[0, 16]
+    end
+
+    def key_location
+      key_path.to_s
+    end
+
+    def key_status
+      ensure_key!
+      path = key_path
+      {
+        fingerprint: key_fingerprint,
+        path: path.to_s,
+        created_at: path.exist? ? path.stat.mtime : nil,
+      }
+    end
+
+    def reset!
+      mutex.synchronize do
+        reset_cached_encryptor!
+        remove_instance_variable(:@key_path) if instance_variable_defined?(:@key_path)
+        remove_instance_variable(:@legacy_encryptor) if instance_variable_defined?(:@legacy_encryptor)
+      end
+    end
+
+    private
+
+    def reset_cached_encryptor!
+      remove_instance_variable(:@current_key) if instance_variable_defined?(:@current_key)
+      remove_instance_variable(:@current_encryptor) if instance_variable_defined?(:@current_encryptor)
+    end
+
+    def reencrypt_calendar_sources(old_encryptor, new_encryptor)
+      CalendarSource.where.not(credentials: nil).find_each do |source|
+        ciphertext = source.read_attribute(:credentials)
+        next if ciphertext.blank?
+
+        data = decrypt_for_rotation(ciphertext, old_encryptor)
+        encrypted = encrypt_with(data, new_encryptor)
+        next if encrypted.blank?
+
+        # Updating the raw encrypted payload; skip the custom credentials= writer.
+        source.update_column(:credentials, encrypted) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+
+    def reencrypt_app_settings(old_encryptor, new_encryptor)
+      AppSetting.find_each do |settings|
+        ciphertext = settings.read_attribute(:apple_credentials_ciphertext) || settings.read_attribute(:apple_username)
+
+        data = if ciphertext.present?
+          decrypt_for_rotation(ciphertext, old_encryptor)
+        else
+          legacy_app_setting_credentials(settings)
+        end
+
+        next if data.blank?
+
+        encrypted = encrypt_with(data, new_encryptor)
+        next if encrypted.blank?
+
+        updates = { apple_credentials_ciphertext: encrypted }
+        updates[:apple_username] = nil if settings.has_attribute?(:apple_username)
+        updates[:apple_app_password] = nil if settings.has_attribute?(:apple_app_password)
+        settings.update_columns(updates) # rubocop:disable Rails/SkipsModelValidations -- migrating encrypted payload without triggering callbacks
+      end
+    end
+
+    def encrypt_with(data, encryptor)
+      hash = coerce_payload(data)
+      normalized = normalize_payload(hash)
+      return if normalized.blank?
+
+      encryptor.encrypt_and_sign(normalized.to_json)
+    end
+
+    def decrypt_for_rotation(ciphertext, primary_encryptor)
+      return empty_hash if ciphertext.blank?
+
+      coerce_payload(
+        decrypt_with(ciphertext, primary_encryptor) || legacy_decrypt(ciphertext),
+      )
+    end
+
+    def decrypt_with(ciphertext, encryptor)
+      return if ciphertext.blank? || encryptor.nil?
+
+      decrypted = encryptor.decrypt_and_verify(ciphertext)
+      coerce_payload(decrypted)
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage
+      nil
+    end
+
+    def legacy_decrypt(ciphertext)
+      encryptor = legacy_encryptor
+      return unless encryptor
+
+      decrypted = encryptor.decrypt_and_verify(ciphertext)
+      hash = coerce_payload(decrypted)
+      hash.presence
+    rescue ActiveSupport::MessageEncryptor::InvalidMessage
+      nil
+    end
+
+    def legacy_encryptor
+      @legacy_encryptor ||= begin
+        secret = rails_key_generator.generate_key("calendar_source_credentials", ActiveSupport::MessageEncryptor.key_len)
+        ActiveSupport::MessageEncryptor.new(secret, cipher: "aes-256-gcm")
+      rescue
+        nil
+      end
+    end
+
+    def legacy_app_setting_credentials(settings)
+      return if settings[:apple_username].blank? && settings[:apple_app_password].blank?
+
+      creds = {}
+      creds[:apple_username] = settings[:apple_username] if settings[:apple_username].present?
+      creds[:apple_app_password] = settings[:apple_app_password] if settings[:apple_app_password].present?
+      creds.with_indifferent_access
+    end
+
+    def rails_key_generator
+      Rails.application.key_generator
+    end
+
+    def parse_json(json)
+      JSON.parse(json).with_indifferent_access
+    rescue JSON::ParserError
+      empty_hash
+    end
+
+    def coerce_payload(value)
+      case value
+      when nil
+        empty_hash
+      when String
+        parsed = parse_json(value)
+        parsed.is_a?(Hash) ? parsed : empty_hash
+      when Hash
+        value.with_indifferent_access
+      else
+        if value.respond_to?(:to_h)
+          value.to_h.with_indifferent_access
+        elsif value.respond_to?(:each_pair)
+          value.each_pair.to_h.with_indifferent_access
+        else
+          empty_hash
+        end
+      end
+    rescue JSON::ParserError
+      empty_hash
+    end
+
+    def normalize_payload(hash)
+      hash.each_with_object({}) do |(key, val), memo|
+        next if val.blank?
+
+        memo[key.to_s] = val
+      end
+    end
+
+    def empty_hash
+      {}.with_indifferent_access
+    end
+
+    def current_encryptor
+      ensure_key!
+      @current_encryptor ||= build_encryptor(@current_key)
+    end
+
+    def build_encryptor(key)
+      secret = ActiveSupport::KeyGenerator.new(key).generate_key(SALT, ActiveSupport::MessageEncryptor.key_len)
+      ActiveSupport::MessageEncryptor.new(secret, cipher: "aes-256-gcm")
+    end
+
+    def generate_and_store_key
+      key = generate_key
+      write_key(key)
+      key
+    end
+
+    def write_key(key)
+      raise ArgumentError, "Invalid key length" unless valid_key?(key)
+
+      path = key_path
+      FileUtils.mkdir_p(path.dirname)
+      File.write(path, key)
+      File.chmod(0o600, path) unless Gem.win_platform?
+    end
+
+    def read_key
+      key = key_path.read.strip
+      raise ArgumentError, "Invalid key length" unless valid_key?(key)
+
+      key
+    end
+
+    def key_path
+      @key_path ||= begin
+        configured = ENV.fetch("CALENDAR_HUB_CREDENTIAL_KEY_PATH", Rails.root.join("storage/credential_key").to_s)
+        Pathname.new(configured).expand_path
+      end
+    end
+
+    def generate_key
+      SecureRandom.hex(KEY_BYTES)
+    end
+
+    def valid_key?(candidate)
+      candidate.is_a?(String) && candidate.present? && candidate.length == HEX_LENGTH && candidate.match?(/\A[0-9a-f]{64}\z/i)
+    end
+
+    def mutex
+      @mutex ||= Mutex.new
+    end
+  end
+end

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -109,6 +109,17 @@
                 <p class="text-slate-300"><%= t("ui.settings.verify_realtime") %></p>
                 <%= link_to t("ui.settings.open_realtime"), realtime_path, class: "inline-block rounded-lg border border-slate-700 px-3 py-2 text-slate-200 hover:border-slate-500" %>
               </div>
+              <div class="rounded-lg border border-slate-800 bg-slate-900/60 p-3 text-xs text-slate-300 space-y-2">
+                <p class="font-semibold text-slate-200"><%= t("ui.settings.credential_key_header") %></p>
+                <% key_status = CalendarHub::CredentialEncryption.key_status %>
+                <p><span class="text-slate-400"><%= t("ui.settings.credential_key_fingerprint") %></span> <code><%= key_status[:fingerprint] %></code></p>
+                <% if key_status[:created_at] %>
+                  <p><span class="text-slate-400"><%= t("ui.settings.credential_key_created_at") %></span> <%= l(key_status[:created_at], format: :long) %></p>
+                <% end %>
+                <p><span class="text-slate-400"><%= t("ui.settings.credential_key_location") %></span> <code><%= key_status[:path] %></code></p>
+                <%= button_to t("ui.settings.rotate_credential_key"), rotate_credential_key_settings_path, method: :post, data: { turbo_stream: true, confirm: t("ui.settings.rotate_credential_key_confirm") }, class: "cursor-pointer inline-flex items-center rounded-lg border border-indigo-700 px-3 py-2 text-sm text-indigo-200 hover:border-indigo-500", form: { data: { controller: "dirty-form", dirty_form_target: "form" } } %>
+                <p class="text-slate-500"><%= t("ui.settings.credential_key_hint") %></p>
+              </div>
               <div class="rounded-lg border border-slate-800 bg-slate-900/60 p-3 text-xs text-slate-300">
                 <% opts = UrlOptions.for_links %>
                 <p class="mb-1"><span class="text-slate-400"><%= t("ui.settings.effective_base_url") %></span> <code><%= opts[:protocol] || "http" %>://<%= opts[:host] %><%= opts[:port] ? ":#{opts[:port]}" : "" %></code></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,6 +112,8 @@ en:
       apple_test_failed: "Apple Calendar test failed: %{error}"
       apple_test_found: "Apple Calendar reachable. Destination found: %{path}"
       apple_test_ok: "Apple Calendar reachable. Credentials accepted."
+      key_rotated: "Credential key rotated."
+      key_rotation_failed: "Rotating credential key failed: %{error}"
       reset: "Settings reset to defaults."
       review_errors: "Please review the errors below."
       saved: "Settings saved."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   resource :settings, only: [:show, :edit, :update] do
     post :test_calendar
     post :reset
+    post :rotate_credential_key
   end
   resources :event_mappings, only: [:index, :create, :destroy, :edit, :update] do
     collection do

--- a/db/migrate/20250926160000_add_credential_ciphertext_to_app_settings.rb
+++ b/db/migrate/20250926160000_add_credential_ciphertext_to_app_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCredentialCiphertextToAppSettings < ActiveRecord::Migration[8.0]
+  def change
+    add_column(:app_settings, :apple_credentials_ciphertext, :text)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_26_140937) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_26_160000) do
   create_table "app_settings", force: :cascade do |t|
     t.string "default_time_zone", default: "UTC", null: false
     t.string "default_calendar_identifier"
@@ -23,6 +23,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_26_140937) do
     t.string "apple_username"
     t.string "apple_app_password"
     t.integer "default_sync_frequency_minutes", default: 60, null: false
+    t.text "apple_credentials_ciphertext"
   end
 
   create_table "calendar_event_audits", force: :cascade do |t|

--- a/test/models/app_setting_test.rb
+++ b/test/models/app_setting_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AppSettingTest < ActiveSupport::TestCase
+  def setup
+    super
+    @original_path = ENV["CALENDAR_HUB_CREDENTIAL_KEY_PATH"]
+    @tmp_key_path = Rails.root.join("tmp", "test_credential_key_#{SecureRandom.hex(4)}")
+    ENV["CALENDAR_HUB_CREDENTIAL_KEY_PATH"] = @tmp_key_path.to_s
+    CalendarHub::CredentialEncryption.reset!
+    CalendarHub::CredentialEncryption.ensure_key!
+  end
+
+  def teardown
+    CalendarHub::CredentialEncryption.reset!
+    File.delete(@tmp_key_path) if @tmp_key_path && File.exist?(@tmp_key_path)
+    if @original_path
+      ENV["CALENDAR_HUB_CREDENTIAL_KEY_PATH"] = @original_path
+    else
+      ENV.delete("CALENDAR_HUB_CREDENTIAL_KEY_PATH")
+    end
+    super
+  end
+
+  test "stores apple credentials encrypted" do
+    settings = AppSetting.instance
+    settings.apple_username = "user@example.com"
+    settings.apple_app_password = "secret-pass"
+
+    assert(settings.save)
+
+    reloaded = AppSetting.instance
+
+    assert_equal("user@example.com", reloaded.apple_username)
+    assert_equal("secret-pass", reloaded.apple_app_password)
+  end
+
+  test "persists nil values when blank" do
+    settings = AppSetting.instance
+    settings.apple_username = ""
+    settings.apple_app_password = nil
+
+    assert(settings.save)
+
+    reloaded = AppSetting.instance
+
+    assert_nil(reloaded.apple_username)
+    assert_nil(reloaded.apple_app_password)
+  end
+
+  test "rotate_credentials_key! reencrypts payload with new key" do
+    settings = AppSetting.instance
+    settings.apple_username = "rotate@example.com"
+    settings.apple_app_password = "rotate-pass"
+
+    assert(settings.save)
+
+    original_fingerprint = settings.credential_key_fingerprint
+
+    settings.rotate_credentials_key!
+    settings.reload
+
+    refute_equal(original_fingerprint, settings.credential_key_fingerprint)
+    assert_equal("rotate@example.com", settings.apple_username)
+    assert_equal("rotate-pass", settings.apple_app_password)
+  end
+end

--- a/test/services/calendar_hub/credential_encryption_test.rb
+++ b/test/services/calendar_hub/credential_encryption_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module CalendarHub
+  class CredentialEncryptionTest < ActiveSupport::TestCase
+    def setup
+      super
+      @original_path = ENV["CALENDAR_HUB_CREDENTIAL_KEY_PATH"]
+      @tmp_key_path = Rails.root.join("tmp", "credential_key_test_#{SecureRandom.hex(4)}")
+      ENV["CALENDAR_HUB_CREDENTIAL_KEY_PATH"] = @tmp_key_path.to_s
+      CredentialEncryption.reset!
+    end
+
+    def teardown
+      CredentialEncryption.reset!
+      if @tmp_key_path && File.exist?(@tmp_key_path)
+        File.delete(@tmp_key_path)
+      end
+      if @original_path
+        ENV["CALENDAR_HUB_CREDENTIAL_KEY_PATH"] = @original_path
+      else
+        ENV.delete("CALENDAR_HUB_CREDENTIAL_KEY_PATH")
+      end
+      super
+    end
+
+    test "ensures key is generated on demand" do
+      refute_path_exists(@tmp_key_path)
+
+      CredentialEncryption.ensure_key!
+      fingerprint = CredentialEncryption.key_fingerprint
+
+      assert_path_exists(@tmp_key_path)
+      assert_equal(16, fingerprint.length)
+    end
+
+    test "encrypt and decrypt round trip" do
+      CredentialEncryption.ensure_key!
+
+      payload = { username: "alice", password: "secret" }
+      ciphertext = CredentialEncryption.encrypt(payload)
+
+      refute_nil(ciphertext)
+
+      decrypted = CredentialEncryption.decrypt(ciphertext)
+
+      assert_equal("alice", decrypted[:username])
+      assert_equal("secret", decrypted[:password])
+    end
+
+    test "decrypt returns empty hash for blank payload" do
+      CredentialEncryption.ensure_key!
+
+      assert_empty(CredentialEncryption.decrypt(nil))
+      assert_empty(CredentialEncryption.decrypt(""))
+    end
+
+    test "key_status returns fingerprint and metadata" do
+      CredentialEncryption.ensure_key!
+      status = CredentialEncryption.key_status
+
+      assert_equal(16, status[:fingerprint].length)
+      assert_equal(@tmp_key_path.to_s, status[:path])
+      assert_kind_of(Time, status[:created_at])
+    end
+
+    test "rotate! generates new key and reencrypts data" do
+      CredentialEncryption.ensure_key!
+      original_fingerprint = CredentialEncryption.key_fingerprint
+
+      source = CalendarSource.create!(
+        name: "Test Source",
+        ingestion_url: "https://example.com/feed.ics",
+        calendar_identifier: "Inbox",
+        credentials: { username: "user", password: "pass" },
+      )
+      settings = AppSetting.instance
+      settings.apple_username = "initial@example.com"
+      settings.apple_app_password = "initial-pass"
+      settings.save!
+
+      CredentialEncryption.rotate!
+      new_fingerprint = CredentialEncryption.key_fingerprint
+
+      refute_equal(original_fingerprint, new_fingerprint)
+
+      fresh_source = CalendarSource.find(source.id)
+      creds = fresh_source.credentials.with_indifferent_access
+
+      assert_equal("user", creds[:username])
+      assert_equal("pass", creds[:password])
+
+      fresh_settings = AppSetting.instance.reload
+
+      assert_equal("initial@example.com", fresh_settings.apple_username)
+      assert_equal("initial-pass", fresh_settings.apple_app_password)
+
+      ciphertext = fresh_source.read_attribute(:credentials)
+      decrypted = CredentialEncryption.decrypt(ciphertext)
+
+      assert_equal("user", decrypted[:username])
+      assert_equal("pass", decrypted[:password])
+    ensure
+      source.destroy
+    end
+
+    test "rotate! raises KeyRotationError when persistence fails" do
+      CredentialEncryption.ensure_key!
+      original_fingerprint = CredentialEncryption.key_fingerprint
+
+      source = CalendarSource.create!(
+        name: "Test Source",
+        ingestion_url: "https://example.com/feed.ics",
+        calendar_identifier: "Inbox",
+        credentials: { username: "user", password: "pass" },
+      )
+
+      CalendarSource
+        .any_instance
+        .stubs(:update_column)
+        .raises(StandardError, "boom")
+
+      assert_raises(CredentialEncryption::KeyRotationError) do
+        CredentialEncryption.rotate!
+      end
+
+      final_fingerprint = CredentialEncryption.key_fingerprint
+
+      assert_equal(original_fingerprint, final_fingerprint)
+    ensure
+      CalendarSource.any_instance.unstub(:update_column)
+      source.destroy
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- replace master-key dependency with a dedicated credential encryptor service that manages key generation, status reporting, and rotation
- migrate `AppSetting` and `CalendarSource` credentials to the new encryptor and surface key controls in the settings UI
- add focused unit tests covering encryption, rotation success/failure, and the app setting workflow
- include a migration to persist encrypted Apple credentials with the new cipher

## Testing
- `toys checks`
