### PR TITLE
Fix sync dead-end causing stale last_synced_at after container restarts

### DIFF
--- a/app/models/calendar_source.rb
+++ b/app/models/calendar_source.rb
@@ -75,9 +75,9 @@ class CalendarSource < ApplicationRecord
   end
 
   def generate_change_hash
-    mappings_hash = event_mappings.active.order(:position).pluck(:pattern, :replacement, :match_type, :case_sensitive).hash
-    settings_hash = [sync_frequency_minutes, sync_window_start_hour, sync_window_end_hour, time_zone].hash
-    [mappings_hash, settings_hash].hash.to_s
+    mappings_data = event_mappings.active.order(:position).pluck(:pattern, :replacement, :match_type, :case_sensitive)
+    settings_data = [sync_frequency_minutes, sync_window_start_hour, sync_window_end_hour, time_zone]
+    Digest::SHA256.hexdigest([mappings_data, settings_data].inspect)
   end
 
   def mark_synced!(token:, timestamp: Time.current)

--- a/app/services/calendar_hub/ingestion/enhanced_ics_adapter.rb
+++ b/app/services/calendar_hub/ingestion/enhanced_ics_adapter.rb
@@ -28,16 +28,11 @@ module CalendarHub
         raise Ingestion::Error, "Failed to fetch ICS feed: #{e.message}"
       end
 
+      # Checks only local configuration state (mappings, settings).
+      # Feed-level change detection (ETag/304) is handled separately by
+      # fetch_events_with_change_detection in the sync service.
       def has_changes?
-        current_hash = source.generate_change_hash
-        stored_hash = source.last_change_hash
-
-        return true if stored_hash.nil?
-
-        feed_result = fetch_events_with_change_detection
-        return true if feed_result[:changed]
-
-        current_hash != stored_hash
+        source.last_change_hash.nil? || source.generate_change_hash != source.last_change_hash
       end
     end
   end

--- a/app/services/calendar_hub/sync/enhanced_sync_service.rb
+++ b/app/services/calendar_hub/sync/enhanced_sync_service.rb
@@ -12,20 +12,17 @@ module CalendarHub
         raise Ingestion::Error, "No ingestion adapter configured" if adapter.nil?
         raise ArgumentError, "Calendar identifier is required" if source.calendar_identifier.blank?
 
-        # Check for changes before doing expensive operations
-        unless adapter.respond_to?(:has_changes?) && adapter.has_changes?
-          Rails.logger.info("[CalendarSync] No changes detected for source=#{source.id}, skipping sync")
-          source.mark_synced!(token: source.sync_token || generate_sync_token, timestamp: Time.current)
-          observer&.finish(status: :success)
-          return []
-        end
-
         started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-        # Fetch events with change detection
+        # Fetch events with change detection (handles HTTP caching via ETag/304)
         if adapter.respond_to?(:fetch_events_with_change_detection)
           result = adapter.fetch_events_with_change_detection
-          return [] unless result[:changed]
+          unless result[:changed]
+            Rails.logger.info("[CalendarSync] No changes detected for source=#{source.id}, skipping sync")
+            source.mark_synced!(token: source.sync_token || generate_sync_token, timestamp: Time.current)
+            observer&.finish(status: :success)
+            return []
+          end
 
           fetched_events = result[:events]
         else

--- a/test/services/calendar_hub/enhanced_sync_service_test.rb
+++ b/test/services/calendar_hub/enhanced_sync_service_test.rb
@@ -20,9 +20,9 @@ module CalendarHub
       )
     end
 
-    test "skips sync when no changes detected" do
-      @adapter.expects(:respond_to?).with(:has_changes?).returns(true)
-      @adapter.expects(:has_changes?).returns(false)
+    test "skips sync when feed returns not modified" do
+      @adapter.expects(:respond_to?).with(:fetch_events_with_change_detection).returns(true)
+      @adapter.expects(:fetch_events_with_change_detection).returns({ changed: false, events: [] })
       @source.expects(:mark_synced!).with(token: anything, timestamp: anything)
       @observer.expects(:finish).with(status: :success)
 
@@ -31,13 +31,13 @@ module CalendarHub
       assert_empty result
     end
 
-    test "updates last_synced_at even when no changes detected" do
+    test "updates last_synced_at when feed returns not modified" do
       source = calendar_sources(:provider)
       source.update_columns(last_synced_at: 3.days.ago, sync_token: "old-token") # rubocop:disable Rails/SkipsModelValidations
 
       adapter = mock("EnhancedIcsAdapter")
-      adapter.expects(:respond_to?).with(:has_changes?).returns(true)
-      adapter.expects(:has_changes?).returns(false)
+      adapter.expects(:respond_to?).with(:fetch_events_with_change_detection).returns(true)
+      adapter.expects(:fetch_events_with_change_detection).returns({ changed: false, events: [] })
 
       observer = mock("Observer")
       observer.expects(:finish).with(status: :success)
@@ -57,7 +57,7 @@ module CalendarHub
       assert_in_delta Time.current, source.last_synced_at, 5.seconds
     end
 
-    test "performs full sync when changes detected" do
+    test "performs full sync when feed has changes" do
       events_data = [
         MockEvent.new(
           "event1",
@@ -72,8 +72,6 @@ module CalendarHub
         ),
       ]
 
-      @adapter.expects(:respond_to?).with(:has_changes?).returns(true)
-      @adapter.expects(:has_changes?).returns(true)
       @adapter.expects(:respond_to?).with(:fetch_events_with_change_detection).returns(true)
       @adapter.expects(:fetch_events_with_change_detection).returns({ changed: true, events: events_data })
 
@@ -107,8 +105,6 @@ module CalendarHub
         ),
       ]
 
-      @adapter.expects(:respond_to?).with(:has_changes?).returns(true)
-      @adapter.expects(:has_changes?).returns(true)
       @adapter.expects(:respond_to?).with(:fetch_events_with_change_detection).returns(false)
       @adapter.expects(:fetch_events).returns(events_data)
 
@@ -125,17 +121,6 @@ module CalendarHub
       result = @service.call
 
       assert_equal 1, result.count
-    end
-
-    test "handles feed not modified response" do
-      @adapter.expects(:respond_to?).with(:has_changes?).returns(true)
-      @adapter.expects(:has_changes?).returns(true)
-      @adapter.expects(:respond_to?).with(:fetch_events_with_change_detection).returns(true)
-      @adapter.expects(:fetch_events_with_change_detection).returns({ changed: false, events: [] })
-
-      result = @service.call
-
-      assert_empty result
     end
   end
 end

--- a/test/services/calendar_hub/ingestion/enhanced_ics_adapter_test.rb
+++ b/test/services/calendar_hub/ingestion/enhanced_ics_adapter_test.rb
@@ -98,33 +98,17 @@ module CalendarHub
         assert_predicate @adapter, :has_changes?
       end
 
-      test "has_changes detects feed changes" do
+      test "has_changes detects local config changes" do
         @source.update!(last_change_hash: @source.generate_change_hash)
 
-        ics_content = <<~ICS
-          BEGIN:VCALENDAR
-          VERSION:2.0
-          PRODID:test
-          BEGIN:VEVENT
-          UID:test-event-1
-          DTSTART:20250925T100000Z
-          DTEND:20250925T110000Z
-          SUMMARY:Test Event
-          END:VEVENT
-          END:VCALENDAR
-        ICS
-
-        stub_request(:get, @source.ingestion_url)
-          .to_return(status: 200, body: ics_content, headers: { "ETag" => '"new-etag"' })
+        # Changing a setting that affects the hash should be detected
+        @source.sync_window_start_hour = 8
 
         assert_predicate @adapter, :has_changes?
       end
 
-      test "has_changes returns false when nothing changed" do
+      test "has_changes returns false when local config unchanged" do
         @source.update!(last_change_hash: @source.generate_change_hash)
-
-        stub_request(:get, @source.ingestion_url)
-          .to_return(status: 304)
 
         refute_predicate @adapter, :has_changes?
       end
@@ -151,10 +135,6 @@ module CalendarHub
 
       test "has_changes returns true when last_change_hash is nil" do
         @source.update!(last_change_hash: nil)
-
-        # Mock the feed check to return not changed
-        stub_request(:get, @source.ingestion_url)
-          .to_return(status: 304)
 
         assert_predicate @adapter, :has_changes?
       end
@@ -254,16 +234,11 @@ module CalendarHub
         assert_empty result[:events]
       end
 
-      test "has_changes handles errors in fetch_events_with_change_detection" do
-        @source.update!(last_change_hash: "some-hash")
+      test "has_changes does not make HTTP requests" do
+        @source.update!(last_change_hash: @source.generate_change_hash)
 
-        stub_request(:get, @source.ingestion_url)
-          .to_raise(StandardError.new("Network error"))
-
-        # Should propagate the error from fetch_events_with_change_detection
-        assert_raises ::CalendarHub::Ingestion::Error do
-          @adapter.has_changes?
-        end
+        # No HTTP stubs — has_changes? should not make any HTTP calls
+        refute_predicate @adapter, :has_changes?
       end
     end
   end


### PR DESCRIPTION
## Summary

- **Fixed a sync dead-end** where sources with unchanged ICS feeds (HTTP 304) would never update `last_synced_at` after a container restart, causing permanently yellow auto-sync pills
- **Root cause**: Two interacting bugs — Ruby's non-deterministic `.hash` invalidated stored change hashes on every process restart, and a bare `return []` in the full sync path skipped `mark_synced!` entirely
- **Made `generate_change_hash` deterministic** using `Digest::SHA256` instead of Ruby's per-process `.hash`
- **Simplified `has_changes?`** to only check local config state (no HTTP requests), eliminating the redundant double-fetch

## Test plan

- [x] All 840 tests pass
- [ ] Deploy and verify previously-yellow auto-sync pills turn blue after next sync cycle
- [ ] Confirm `last_synced_at` updates for sources returning 304 Not Modified
- [ ] Verify sources with actual feed changes still sync normally